### PR TITLE
Update codebase for le_node 0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,44 @@
 bunyan-logentries [![Build Status](https://secure.travis-ci.org/nemtsov/node-bunyan-logentries.png)](http://travis-ci.org/nemtsov/node-bunyan-logentries)
 =================
 
-Bunyan logger stream for Logentries
+Bunyan logger stream for Logentries.
+
+
+Installation
+------------
+
+First install bunyan:
+
+```shell
+$ npm install --save bunyan
+```
+
+Then install bunyan-logentries:
+
+```shell
+$ npm install --save bunyan-logentries
+```
 
 
 Usage
 -----
 
-**Note**: the stream-type must be `raw`.
+**Note**: the stream type must be `raw`.
 
-```
-var bunyanLogentries = require('bunyan-logentries')
+```js
+var bunyan = require('bunyan');
+var bunyanLogentries = require('bunyan-logentries');
 
 var logger = bunyan.createLogger({
-  config.streams = [{
+  streams: [{
       level: 'info'
-    , stream: bunyanLogentries.createStream({token: token})
+    , stream: bunyanLogentries.createStream({ token: token })
     , type: 'raw'
-  }]
-})
+  }];
+});
 ```
+
+`token` should be obtained from [Logentries](https://logentries.com).
 
 
 License

--- a/index.js
+++ b/index.js
@@ -1,26 +1,24 @@
-var logentries = require('node-logentries')
+var logentries = require('le_node')
   , Stream = require('stream').Stream
   , util = require('util')
-  , LBS
+  , LBS;
 
-exports.LogentriesBunyanStream = LogentriesBunyanStream
+exports.LogentriesBunyanStream = LogentriesBunyanStream;
 exports.createStream = function (config, options) {
-  return new LogentriesBunyanStream(config, options)
-}
+  return new LogentriesBunyanStream(config, options);
+};
 
 /**
  * LogentriesBunyanStream
  *
  * @param {Object} config Logentries config
- * @param {Object} [options] {exludes: Object} keys to exclude from logentries
  */
-
-function LogentriesBunyanStream(config, options) {
+function LogentriesBunyanStream(config) {
   if (!config || !config.token) {
-    throw new Error('config.token must be set')
+    throw new Error('config.token must be set');
   }
-  Stream.call(this)
-  this.writable = true
+  Stream.call(this);
+  this.writable = true;
   config.levels = {
       trace: 0  // trace -> debug
     , debug: 0  // debug -> debug
@@ -28,45 +26,27 @@ function LogentriesBunyanStream(config, options) {
     , warn: 3  // warn -> warning
     , error: 4  // error -> err
     , fatal: 7  // fatal -> emerg
-  }
-  this._logger = logentries.logger(config)
-  this._options = options || {}
-  this._options.excludes = this._options.excludes || {
-      hostname:1, pid: 1
-    , level:1, time:1, name:1, v:1
-  }
+  };
+  this._logger = logentries.logger(config);
 }
 
-util.inherits(LogentriesBunyanStream, Stream)
-LBS = LogentriesBunyanStream.prototype
+util.inherits(LogentriesBunyanStream, Stream);
+LBS = LogentriesBunyanStream.prototype;
 
 LBS.write = function (rec) {
-  if (!this.writable) throw new Error('failed to write to a closed stream')
-  var str = this._serializeRec(rec)
-  this._logger.log(this._resolveLevel(rec.level), str)
-}
+  if (!this.writable) throw new Error('failed to write to a closed stream');
+  this._logger.log(this._resolveLevel(rec.level), rec);
+};
 
 LBS.end = function (rec) {
-  if (arguments.length) this.write(rec)
-  this.writable = false
-}
+  if (arguments.length) this.write(rec);
+  this.writable = false;
+  this._logger.end();
+};
 
 LBS.destroy = function () {
-  this.writable = false
-}
-
-LBS._serializeRec = function (rec) {
-  var excl = this._options.excludes
-    , seen = []
-  function safeFilter(key, val) {
-    if (excl[key] || ('' === val)) return
-    if (!val || typeof (val) !== 'object') return val
-    if (seen.indexOf(val) !== -1) return '[Circular]'
-    seen.push(val)
-    return val
-  }
-  return JSON.stringify(rec, safeFilter)
-}
+  this.writable = false;
+};
 
 LBS._resolveLevel = function (bunyanLevel) {
   var levelToName = {
@@ -76,6 +56,6 @@ LBS._resolveLevel = function (bunyanLevel) {
     , 40: 'warn'
     , 50: 'error'
     , 60: 'fatal'
-  }
-  return levelToName[bunyanLevel]
-}
+  };
+  return levelToName[bunyanLevel];
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/nemtsov/node-bunyan-logentries/issues"
   },
   "dependencies": {
-    "node-logentries": "~0.1.0"
+    "le_node": "~0.2.0"
   }
 }


### PR DESCRIPTION
node-logentries has been significantly changed recently and renamed to le_node. This PR uses new library version. I have also removed _serializeRec function since it's basically the job of bunyan serializers and stream forwarding lib has nothing to do with it.
