### PR TITLE
also check if the level was passed as a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,11 +51,17 @@ LBS.destroy = function () {
 LBS._resolveLevel = function (bunyanLevel) {
   var levelToName = {
       10: 'trace'
+    , trace: 'trace'
     , 20: 'debug'
+    , debug: 'debug'
     , 30: 'info'
+    , info: 'info'
     , 40: 'warn'
+    , warn: 'warn'
     , 50: 'error'
+    , error: 'error'
     , 60: 'fatal'
+    , fatal: 'fatal'
   };
   return levelToName[bunyanLevel];
 };


### PR DESCRIPTION
I don't know if this is generally a problem, or was just a problem with our use case (we override our web framework's logger to use bunyan). We ran into a situation where the log level was passed as a string instead of being passed as a number.

So, don't know if you'd want to merge this in, but putting it out there just in case.
