### PR TITLE
Adds the option to pass a transform function to format the log record before sending it to logEntries and adds some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ results
 
 npm-debug.log
 node_modules
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ results
 npm-debug.log
 node_modules
 .idea/
+coverage/
+html-report/

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,26 @@
+{
+  "globals": {
+    "describe": false,
+    "it": false,
+    "before": false,
+    "beforeEach": false,
+    "after": false,
+    "afterEach": false
+  },
+  "mocha": true,
+  "strict": true,
+  "node": true,
+  "noempty": true,
+  "noarg": true,
+  "eqeqeq": true,
+  "nocomma": true,
+  "immed": true,
+  "nonbsp": true,
+  "bitwise": true,
+  "curly": true,
+  "undef": true,
+  "nonew": true,
+  "forin": true,
+  "expr": true,
+  "es3": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 
 node_js:
   - 0.10
+
+after_success: 'npm run coveralls'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-bunyan-logentries [![Build Status](https://secure.travis-ci.org/nemtsov/node-bunyan-logentries.png)](http://travis-ci.org/nemtsov/node-bunyan-logentries) [![Coverage Status](https://coveralls.io/repos/<account>/<repository>/badge.svg?branch=master)](https://coveralls.io/r/<account>/<repository>?branch=master)
+bunyan-logentries [![Build Status](https://secure.travis-ci.org/nemtsov/node-bunyan-logentries.png)](http://travis-ci.org/nemtsov/node-bunyan-logentries)
 =================
 
 Bunyan logger stream for Logentries.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,43 @@ var logger = bunyan.createLogger({
 });
 ```
 
+Advanced Usage
+----
+```js
+var bunyan = require('bunyan');
+var bunyanLogentries = require('bunyan-logentries');
+
+var logger = bunyan.createLogger({
+  streams: [{
+    level: 'info',
+    stream: bunyanLogentries.createStream({ 
+        token: token,
+        levels: { // LogEntries Mapping:debug:0, info:1, notice:2, warning:3, err:4, crit:5, alert:6, emerg:7
+            trace: 0,
+            debug: 0,
+            info: 1,
+            warn: 3,
+            error: 4
+            fatal: 7
+        },
+        timestamp: false,
+        secure: true,
+        host:'api.logentries.com'
+    }),
+    type: 'raw'
+  },{
+    transform: function(logRecord){
+        // do whatever you like to the record and then return it
+        logRecord.hostname = logRecord.hostname.toUpperCase();
+        delete logRecord.v;
+        return logRecord
+    },
+    defaultLevel: 'info'
+  }];
+});
+```
+
+
 `token` should be obtained from [Logentries](https://logentries.com).
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-bunyan-logentries [![Build Status](https://secure.travis-ci.org/nemtsov/node-bunyan-logentries.png)](http://travis-ci.org/nemtsov/node-bunyan-logentries)
+bunyan-logentries [![Build Status](https://secure.travis-ci.org/nemtsov/node-bunyan-logentries.png)](http://travis-ci.org/nemtsov/node-bunyan-logentries) [![Coverage Status](https://coveralls.io/repos/<account>/<repository>/badge.svg?branch=master)](https://coveralls.io/r/<account>/<repository>?branch=master)
 =================
 
 Bunyan logger stream for Logentries.

--- a/index.js
+++ b/index.js
@@ -1,61 +1,72 @@
-var logentries = require('le_node')
-  , Stream = require('stream').Stream
-  , util = require('util')
-  , LBS;
+var logentries = require('le_node');
+var Stream = require('stream').Stream;
+var util = require('util');
+var LBS;
+
+function isFunction(functionToCheck) {
+    var getType = {};
+    return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+}
 
 exports.LogentriesBunyanStream = LogentriesBunyanStream;
 exports.createStream = function (config, options) {
-  return new LogentriesBunyanStream(config, options);
+    return new LogentriesBunyanStream(config, options);
 };
 
 /**
  * LogentriesBunyanStream
  *
- * @param {Object} config Logentries config
+ * @param {Object} opts Logentries config and custom transform function
  */
-function LogentriesBunyanStream(config) {
-  if (!config || !config.token) {
-    throw new Error('config.token must be set');
-  }
-  Stream.call(this);
-  this.writable = true;
-  config.levels = {
-      trace: 0  // trace -> debug
-    , debug: 0  // debug -> debug
-    , info: 1  // info -> info
-    , warn: 3  // warn -> warning
-    , error: 4  // error -> err
-    , fatal: 7  // fatal -> emerg
-  };
-  this._logger = logentries.logger(config);
+function LogentriesBunyanStream(opts) {
+    if (!opts || !opts.token) {
+        throw new Error('config.token must be set');
+    }
+    this.transform = opts.transform;
+    delete opts.transform;
+    Stream.call(this);
+    this.writable = true;
+
+    opts.levels = opts.levels || {
+            trace: 0,  // trace -> debug
+            debug: 0,  // debug -> debug
+            info: 1,  // info -> info
+            warn: 3,  // warn -> warning
+            error: 4,  // error -> err
+            fatal: 7  // fatal -> emerg
+        };
+    this._logger = logentries.logger(opts);
 }
 
 util.inherits(LogentriesBunyanStream, Stream);
 LBS = LogentriesBunyanStream.prototype;
 
 LBS.write = function (rec) {
-  if (!this.writable) throw new Error('failed to write to a closed stream');
-  this._logger.log(this._resolveLevel(rec.level), rec);
+    if (!this.writable) throw new Error('failed to write to a closed stream');
+    if (isFunction(this.transform)) {
+        rec = this.transform(rec);
+    }
+    this._logger.log(this._resolveLevel(rec.level), rec);
 };
 
 LBS.end = function (rec) {
-  if (arguments.length) this.write(rec);
-  this.writable = false;
-  this._logger.end();
+    if (arguments.length) this.write(rec);
+    this.writable = false;
+    this._logger.end();
 };
 
 LBS.destroy = function () {
-  this.writable = false;
+    this.writable = false;
 };
 
 LBS._resolveLevel = function (bunyanLevel) {
-  var levelToName = {
-      10: 'trace'
-    , 20: 'debug'
-    , 30: 'info'
-    , 40: 'warn'
-    , 50: 'error'
-    , 60: 'fatal'
-  };
-  return levelToName[bunyanLevel];
+    var levelToName = {
+        10: 'trace',
+        20: 'debug',
+        30: 'info',
+        40: 'warn',
+        50: 'error',
+        60: 'fatal'
+    };
+    return levelToName[bunyanLevel];
 };

--- a/index.js
+++ b/index.js
@@ -43,10 +43,11 @@ LBS = LogentriesBunyanStream.prototype;
 
 LBS.write = function (rec) {
     if (!this.writable) throw new Error('failed to write to a closed stream');
+    var logentriesLevel = this._resolveLevel(rec.level)
     if (isFunction(this.transform)) {
         rec = this.transform(rec);
     }
-    this._logger.log(this._resolveLevel(rec.level), rec);
+    this._logger.log(logentriesLevel, rec);
 };
 
 LBS.end = function (rec) {

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+'use strict';
 var logentries = require('le_node');
 var Stream = require('stream').Stream;
 var util = require('util');
@@ -42,7 +43,12 @@ util.inherits(LogentriesBunyanStream, Stream);
 LBS = LogentriesBunyanStream.prototype;
 
 LBS.write = function (rec) {
-    if (!this.writable) throw new Error('failed to write to a closed stream');
+    if(!rec){
+        throw new Error('nothing passed to log');
+    }
+    if (!this.writable) {
+        throw new Error('failed to write to a closed stream');
+    }
     var levelAsString = this._resolveLevel(rec.level);
     if (isFunction(this.transform)) {
         rec = this.transform(rec);
@@ -51,7 +57,9 @@ LBS.write = function (rec) {
 };
 
 LBS.end = function (rec) {
-    if (arguments.length) this.write(rec);
+    if (arguments.length) {
+        this.write(rec);
+    }
     this.writable = false;
     this._logger.end();
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha test",
     "pretest": "jshint index.js test.js",
-    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- test.js -R spec"
+    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- test.js -R spec",
+    "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
   },
   "repository": {
     "type": "git",
@@ -26,6 +27,7 @@
   },
   "devDependencies": {
     "chai": "^2.3.0",
+    "coveralls": "^2.11.2",
     "jshint": "^2.7.0",
     "mocha": "^2.2.4",
     "sinon": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Bunyan logger stream for Logentries",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "mocha test",
+    "pretest": "jshint index.js test.js",
+    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- test.js -R spec"
   },
   "repository": {
     "type": "git",
@@ -24,6 +26,7 @@
   },
   "devDependencies": {
     "chai": "^2.3.0",
+    "jshint": "^2.7.0",
     "mocha": "^2.2.4",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0"

--- a/package.json
+++ b/package.json
@@ -21,5 +21,11 @@
   },
   "dependencies": {
     "le_node": "~0.2.1"
+  },
+  "devDependencies": {
+    "chai": "^2.3.0",
+    "mocha": "^2.2.4",
+    "sinon": "^1.14.1",
+    "sinon-chai": "^2.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/nemtsov/node-bunyan-logentries/issues"
   },
   "dependencies": {
-    "le_node": "~0.2.0"
+    "le_node": "~0.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha test",
     "pretest": "jshint index.js test.js",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- test.js -R spec",
-    "coveralls": "cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
+    "coveralls": "npm run coverage && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,10 +1,86 @@
-var assert = require('assert')
-  , bl = require('./index')
-  , inst
+'use strict';
 
-inst = bl.createStream({token: 'rnd'})
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+var sinonChai = require("sinon-chai");
+chai.use(sinonChai);
+chai.config.includeStack = true;
+sinon.assert.expose(chai.assert, {prefix: ""});
 
-//TODO: destub
-assert('object' === typeof inst)
+var logentriesBunyan = require('./index');
 
-console.log('ok')
+describe('LogEntries Stream', function () {
+    var stream;
+    var logger;
+
+    beforeEach(function () {
+        logger = {
+            log: function () {
+            }
+        };
+        stream = logentriesBunyan.createStream({token: 'atoken'});
+        sinon.stub(logger, 'log', function () {
+            //console.log('log:', arguments);
+        });
+        stream._logger = logger;
+    });
+
+    it('works', function () {
+        stream.write({level: 10, msg: 'This is a test', hostname: 'my-machine'});
+        expect(logger.log).to.have.been.called.once;
+        expect(logger.log.args[0].length).to.equal(2);
+    });
+
+    describe('log levels', function(){
+        it('translates bunyan level codes to strings', function () {
+            stream.write({level: 10});
+            expect(logger.log.args[0][0]).to.equal('trace');
+            stream.write({level: 20});
+            expect(logger.log.args[1][0]).to.equal('debug');
+            stream.write({level: 30});
+            expect(logger.log.args[2][0]).to.equal('info');
+            stream.write({level: 40});
+            expect(logger.log.args[3][0]).to.equal('warn');
+            stream.write({level: 50});
+            expect(logger.log.args[4][0]).to.equal('error');
+            stream.write({level: 60});
+            expect(logger.log.args[5][0]).to.equal('fatal');
+        });
+
+        it('sets a default level if not level is present', function () {
+            stream.write({level: 500});
+            expect(logger.log.args[0][0]).to.equal('info');
+        });
+    });
+
+    describe('transform function', function(){
+        it('performs the given transform function', function(){
+            stream = logentriesBunyan.createStream({token: 'atoken'}, {transform: function(rec){
+                rec.message = rec.msg.toUpperCase();
+                delete rec.msg;
+                return rec;
+            }});
+            stream._logger = logger;
+            stream.write({level:20, msg: 'my message'});
+            expect(logger.log.args[0][1].msg).to.not.exist;
+            expect(logger.log.args[0][1].message).to.exist;
+            expect(logger.log.args[0][1].message).to.equal('MY MESSAGE');
+        });
+
+        it('if not transform function is provided it will log json', function(){
+            stream.write({level:20, msg: 'my message'});
+            expect(logger.log.args[0][1].msg).to.exist;
+            expect(logger.log.args[0][1].msg).to.equal('my message');
+        });
+
+        it('can log plain text using a transform function', function(){
+            stream = logentriesBunyan.createStream({token: 'atoken'}, {transform: function(rec){
+                return rec.level + '|'+ rec.hostname +'|' + rec.msg;
+            }});
+            stream._logger = logger;
+            stream.write({level: 'debug', msg:'my message', hostname: 'my host'});
+            expect(logger.log.args[0][1]).to.equal('debug|my host|my message');
+        });
+    });
+});

--- a/test.js
+++ b/test.js
@@ -16,13 +16,10 @@ describe('LogEntries Stream', function () {
 
     beforeEach(function () {
         logger = {
-            log: function () {
-            }
+            log: sinon.spy(),
+            end: sinon.spy()
         };
         stream = logentriesBunyan.createStream({token: 'atoken'});
-        sinon.stub(logger, 'log', function () {
-            //console.log('log:', arguments);
-        });
         stream._logger = logger;
     });
 
@@ -32,7 +29,35 @@ describe('LogEntries Stream', function () {
         expect(logger.log.args[0].length).to.equal(2);
     });
 
-    describe('log levels', function(){
+    describe('edge cases', function(){
+        it('throws when a token is not passed', function () {
+            expect(logentriesBunyan.createStream).to.throw('config.token must be set');
+        });
+
+        it('throws if nothing is passed', function(){
+            expect(stream.write).to.throw("nothing passed to log");
+        });
+
+        it('throws if the stream is closed', function () {
+            stream.end();
+            expect(stream.write.bind(stream, {level:10, msg:'I should throw'})).to.throw('failed to write to a closed stream');
+        });
+
+        it('logs the last message before the stream is closed', function(){
+            stream.end({level:10, msg: 'last message'});
+            expect(logger.log).to.have.been.called.once;
+            expect(logger.end).to.have.been.called.once;
+            expect(logger.log.args[0].length).to.equal(2);
+            expect(stream.write.bind(stream, {level:10, msg:'I should throw'})).to.throw('failed to write to a closed stream');
+        });
+
+        it('throws if the stream is destroyed', function () {
+            stream.destroy();
+            expect(stream.write.bind(stream, {level:10, msg:'I should throw'})).to.throw('failed to write to a closed stream');
+        });
+    });
+
+    describe('log levels', function () {
         it('translates bunyan level codes to strings', function () {
             stream.write({level: 10});
             expect(logger.log.args[0][0]).to.equal('trace');
@@ -54,32 +79,36 @@ describe('LogEntries Stream', function () {
         });
     });
 
-    describe('transform function', function(){
-        it('performs the given transform function', function(){
-            stream = logentriesBunyan.createStream({token: 'atoken'}, {transform: function(rec){
-                rec.message = rec.msg.toUpperCase();
-                delete rec.msg;
-                return rec;
-            }});
+    describe('transform function', function () {
+        it('performs the given transform function', function () {
+            stream = logentriesBunyan.createStream({token: 'atoken'}, {
+                transform: function (rec) {
+                    rec.message = rec.msg.toUpperCase();
+                    delete rec.msg;
+                    return rec;
+                }
+            });
             stream._logger = logger;
-            stream.write({level:20, msg: 'my message'});
+            stream.write({level: 20, msg: 'my message'});
             expect(logger.log.args[0][1].msg).to.not.exist;
             expect(logger.log.args[0][1].message).to.exist;
             expect(logger.log.args[0][1].message).to.equal('MY MESSAGE');
         });
 
-        it('if not transform function is provided it will log json', function(){
-            stream.write({level:20, msg: 'my message'});
+        it('if not transform function is provided it will log json', function () {
+            stream.write({level: 20, msg: 'my message'});
             expect(logger.log.args[0][1].msg).to.exist;
             expect(logger.log.args[0][1].msg).to.equal('my message');
         });
 
-        it('can log plain text using a transform function', function(){
-            stream = logentriesBunyan.createStream({token: 'atoken'}, {transform: function(rec){
-                return rec.level + '|'+ rec.hostname +'|' + rec.msg;
-            }});
+        it('can log plain text using a transform function', function () {
+            stream = logentriesBunyan.createStream({token: 'atoken'}, {
+                transform: function (rec) {
+                    return rec.level + '|' + rec.hostname + '|' + rec.msg;
+                }
+            });
             stream._logger = logger;
-            stream.write({level: 'debug', msg:'my message', hostname: 'my host'});
+            stream.write({level: 'debug', msg: 'my message', hostname: 'my host'});
             expect(logger.log.args[0][1]).to.equal('debug|my host|my message');
         });
     });


### PR DESCRIPTION
Hello,
I had the requirement to format the log string before sending it over to log entries. I forked your repo and added some functionality that is not specific to my case and I think that others will benefit from this. I also linted the code and added some basic tests.
## ChangeLog
- Adds an optional transform function that can be passed in the options argument
- Adds a default log level that can be passed in the options argument (not sure if a default should be set anyway or throw when a level is not provided)
- Adds some basic tests
- Added package.json scripts for running jshint, tests and coverage
- Updated Readme with a more advanced example
